### PR TITLE
Updates `holidays_for_year_and_zone` to avoid unecessary output

### DIFF
--- a/vacances_scolaires_france/__init__.py
+++ b/vacances_scolaires_france/__init__.py
@@ -95,7 +95,7 @@ class SchoolHolidayDates(object):
 
     def holidays_for_year_and_zone(self, year, zone):
         return {
-            k: v
+            k: v[self.zone_key(zone)]
             for k, v in self.holidays_for_year(year).items()
             if self.is_holiday_for_zone(k, zone)
         }


### PR DESCRIPTION
Updates the method `holidays_for_year_and_zone` to only output the data for desired zone.
The method now has the following output:
```py
{datetime.date(1990, 10, 27): True,
 datetime.date(1990, 10, 28): True,
 datetime.date(1990, 10, 29): True,
 datetime.date(1990, 10, 30): True,
 datetime.date(1990, 10, 31): True,
...
}
```
instead of something like:
```py
{datetime.date(1990, 10, 27): {'date': datetime.date(1990, 10, 27),
  'vacances_zone_a': True,
  'vacances_zone_b': True,
  'vacances_zone_c': True,
  'nom_vacances': 'Vacances de la Toussaint'},
 datetime.date(1990, 10, 28): {'date': datetime.date(1990, 10, 28),
  'vacances_zone_a': True,
  'vacances_zone_b': True,
  'vacances_zone_c': True,
  'nom_vacances': 'Vacances de la Toussaint'},
...
}
```