### PR TITLE
Make it faster to find school holyday

### DIFF
--- a/vacances_scolaires_france/__init__.py
+++ b/vacances_scolaires_france/__init__.py
@@ -83,10 +83,7 @@ class SchoolHolidayDates(object):
     def holidays_for_year(self, year):
         if year < self.min_year or year > self.max_year:
             raise UnsupportedYearException("No data for year: " + str(year))
-        
-        res = {k: v for k, v in self.data.items() if k.year == year}
-
-        return res
+        return {k: v for k, v in self.data.items() if k.year == year}
 
     def holiday_for_year_by_name(self, year, name):
         self.check_name(name)


### PR DESCRIPTION
Quelques améliorations qui permettent de réduire le temps de calcul d'un facteur 10 :
- Précalcule lors de l'initialisation de la plage d'années couvert par les données
- Suppression du dictionnaire intermédiaire ne contenant que les jours de l'année lors de la recherche pour déterminé si un jour est  ( en python les clés de dictionnaire sont hashé, la recherche d'un élément s'effectue donc en temps constant peu importe la taille du dictionnaire )